### PR TITLE
Fix code scanning alert no. 2: Incomplete regular expression for hostnames

### DIFF
--- a/cmd/generate/config/rules/sidekiq.go
+++ b/cmd/generate/config/rules/sidekiq.go
@@ -40,7 +40,7 @@ func SidekiqSensitiveUrl() *config.Rule {
 	r := config.Rule{
 		Description: "Uncovered a Sidekiq Sensitive URL, potentially exposing internal job queues and sensitive operation details.",
 		RuleID:      "sidekiq-sensitive-url",
-		Regex:       regexp.MustCompile(`(?i)\bhttps?://([a-f0-9]{8}:[a-f0-9]{8})@(?:gems.contribsys.com|enterprise.contribsys.com)(?:[\/|\#|\?|:]|$)`),
+		Regex:       regexp.MustCompile(`(?i)\bhttps?://([a-f0-9]{8}:[a-f0-9]{8})@(?:gems\.contribsys\.com|enterprise\.contribsys\.com)(?:[\/|\#|\?|:]|$)`),
 		Keywords:    []string{"gems.contribsys.com", "enterprise.contribsys.com"},
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/devsecopskallie/gitleaks/security/code-scanning/2](https://github.com/devsecopskallie/gitleaks/security/code-scanning/2)

To fix the problem, we need to escape the dots in the regular expression to ensure that they match only literal dots and not any character. This can be done by replacing each dot with `\.`. Additionally, we can use raw string literals to avoid having to escape backslashes, making the regular expression more readable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
