### PR TITLE
Fix code scanning alert no. 5: Incomplete regular expression for hostnames

### DIFF
--- a/cmd/generate/config/rules/slack.go
+++ b/cmd/generate/config/rules/slack.go
@@ -272,7 +272,7 @@ func SlackWebHookUrl() *config.Rule {
 		Description: "Discovered a Slack Webhook, which could lead to unauthorized message posting and data leakage in Slack channels.",
 		// If this generates too many false-positives we should define an allowlist (e.g., "xxxx", "00000").
 		Regex: regexp.MustCompile(
-			`^(?:https?://)?hooks.slack.com/(?:services|workflows)/[A-Za-z0-9+/]{43,46}`),
+			`^(?:https?://)?hooks\.slack\.com/(?:services|workflows)/[A-Za-z0-9+/]{43,46}`),
 		Keywords: []string{
 			"hooks.slack.com",
 		},


### PR DESCRIPTION
Fixes [https://github.com/devsecopskallie/gitleaks/security/code-scanning/5](https://github.com/devsecopskallie/gitleaks/security/code-scanning/5)

To fix the problem, we need to escape the dot in the regular expression to ensure it matches only a literal dot and not any character. This can be done by replacing the dot with `\.`. Additionally, we can use a raw string literal to avoid having to escape the backslash itself, making the regular expression more readable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
